### PR TITLE
Improve docs and API key handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.log
+session.log
+llm_analysis.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # pentest_agent
+
+`pentest_agent` is a command line tool that combines a tmux shell environment with an OpenAI assistant. It helps analyse commands and outputs during penetration testing exercises and suggests next steps.
+
+## Requirements
+
+- Python 3.9+
+- `openai` and `rich` Python packages
+
+## Setup
+
+1. Clone this repository.
+2. (Optional) create and activate a virtual environment.
+3. Install dependencies:
+   ```bash
+   pip install openai rich
+   ```
+4. Provide your OpenAI API key using the `OPENAI_API_KEY` environment variable:
+   ```bash
+   export OPENAI_API_KEY=<your-key>
+   ```
+
+## Usage
+
+Launch the assistant with:
+
+```bash
+python command.py
+```
+
+Choose one of the modes offered in the menu to start an interactive session or analyse command output. Logs are saved in `session.log` and `llm_analysis.txt`.
+
+## Disclaimer
+
+Use this tool only on machines you are authorised to test.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Launch the assistant with:
 python command.py
 ```
 
-Choose one of the modes offered in the menu to start an interactive session or analyse command output. Logs are saved in `session.log` and `llm_analysis.txt`.
+Choose one of the modes offered in the menu to start an interactive session or analyse command output. Errors are printed to the console and command transcripts are saved in `session.log` and `llm_analysis.txt`.
 
 To run the unit tests:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 - Python 3.9+
-- `openai` and `rich` Python packages
+- Dependencies listed in `requirements.txt`
 
 ## Setup
 
@@ -13,7 +13,7 @@
 2. (Optional) create and activate a virtual environment.
 3. Install dependencies:
    ```bash
-   pip install openai rich
+   pip install -r requirements.txt
    ```
 4. Provide your OpenAI API key using the `OPENAI_API_KEY` environment variable:
    ```bash
@@ -29,6 +29,12 @@ python command.py
 ```
 
 Choose one of the modes offered in the menu to start an interactive session or analyse command output. Logs are saved in `session.log` and `llm_analysis.txt`.
+
+To run the unit tests:
+
+```bash
+python -m unittest discover tests
+```
 
 ## Disclaimer
 

--- a/command.py
+++ b/command.py
@@ -16,8 +16,11 @@ CYAN    = "\033[96m"
 RESET   = "\033[0m"
 BOLD    = "\033[1m"
 
-# Initialisation du client OpenAI (remplacez la clé par la vôtre)
-client = OpenAI(api_key='REPLACE')
+# Initialisation du client OpenAI via la variable d'environnement
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise RuntimeError("The OPENAI_API_KEY environment variable is not set")
+client = OpenAI(api_key=api_key)
 
 # Tarification par modèle (en USD pour 1M tokens)
 pricing = {

--- a/command.py
+++ b/command.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import os
 import re
+import logging
 from openai import OpenAI
 from rich.console import Console
 from rich.markdown import Markdown
@@ -15,6 +16,14 @@ MAGENTA = "\033[95m"
 CYAN    = "\033[96m"
 RESET   = "\033[0m"
 BOLD    = "\033[1m"
+
+# Configuration du logger
+logging.basicConfig(
+    filename="pentest_agent.log",
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 # Initialisation du client OpenAI via la variable d'environnement
 api_key = os.getenv("OPENAI_API_KEY")
@@ -66,11 +75,17 @@ def get_gpt4_response(prompt, model):
             {"role": "user", "content": prompt}
         ]
     console = Console()
-    with console.status("Chargement du modèle...", spinner="bouncingBar"):
-        response = client.chat.completions.create(
-            model=model,
-            messages=messages
-        )
+    try:
+        with console.status("Chargement du modèle...", spinner="bouncingBar"):
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages
+            )
+    except Exception as e:
+        logger.exception("OpenAI API request failed")
+        console.print(f"[bold red]OpenAI API request failed: {e}[/bold red]")
+        return "", 0.0, None
+
     content = response.choices[0].message.content
     usage = response.usage
     cost = compute_cost(model, usage)
@@ -87,6 +102,7 @@ def log_interaction(title, input_text, llm_response):
         f.write(input_text + "\n")
         f.write("LLM Response:\n")
         f.write(llm_response + "\n\n")
+    logger.info("%s\nInput: %s\nLLM Response: %s", title, input_text, llm_response)
 
 def launch_tmux_shell():
     """
@@ -195,6 +211,7 @@ def execute_automatic_command(model):
     )
     gpt_response, cost, usage = get_gpt4_response(prompt, model)
     update_total_cost(cost)
+    logger.info("Automatic command GPT response: %s", gpt_response)
     # Extraction de la commande depuis le bloc de code bash
     code_block = re.search(r'```(?:bash)?\s*([\s\S]+?)\s*```', gpt_response)
     if code_block:
@@ -208,10 +225,12 @@ def execute_automatic_command(model):
             output = subprocess.check_output(command_extracted, shell=True, stderr=subprocess.STDOUT, text=True)
         except subprocess.CalledProcessError as e:
             output = e.output
+            logger.error("Command execution failed: %s", e)
         console.print(f"\n[bold yellow]===== Sortie de la commande =====[/bold yellow]\n{output}")
         log_interaction("Commande automatique exécutée", command_extracted, output)
     else:
         console.print(f"[yellow]Commande annulée.[/yellow]")
+        logger.info("Automatic command cancelled by user")
     console.print(f"[bold magenta]Coût API pour cette requête: ${cost:.5f}[/bold magenta]")
     console.print(f"[bold magenta]Coût total accumulé: ${total_api_cost:.5f}[/bold magenta]")
 

--- a/command.py
+++ b/command.py
@@ -2,7 +2,6 @@ import subprocess
 import sys
 import os
 import re
-import logging
 from openai import OpenAI
 from rich.console import Console
 from rich.markdown import Markdown
@@ -17,13 +16,6 @@ CYAN    = "\033[96m"
 RESET   = "\033[0m"
 BOLD    = "\033[1m"
 
-# Configuration du logger
-logging.basicConfig(
-    filename="pentest_agent.log",
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-)
-logger = logging.getLogger(__name__)
 
 # Initialisation du client OpenAI via la variable d'environnement
 api_key = os.getenv("OPENAI_API_KEY")
@@ -82,7 +74,6 @@ def get_gpt4_response(prompt, model):
                 messages=messages
             )
     except Exception as e:
-        logger.exception("OpenAI API request failed")
         console.print(f"[bold red]OpenAI API request failed: {e}[/bold red]")
         return "", 0.0, None
 
@@ -102,7 +93,6 @@ def log_interaction(title, input_text, llm_response):
         f.write(input_text + "\n")
         f.write("LLM Response:\n")
         f.write(llm_response + "\n\n")
-    logger.info("%s\nInput: %s\nLLM Response: %s", title, input_text, llm_response)
 
 def launch_tmux_shell():
     """
@@ -211,7 +201,6 @@ def execute_automatic_command(model):
     )
     gpt_response, cost, usage = get_gpt4_response(prompt, model)
     update_total_cost(cost)
-    logger.info("Automatic command GPT response: %s", gpt_response)
     # Extraction de la commande depuis le bloc de code bash
     code_block = re.search(r'```(?:bash)?\s*([\s\S]+?)\s*```', gpt_response)
     if code_block:
@@ -225,12 +214,11 @@ def execute_automatic_command(model):
             output = subprocess.check_output(command_extracted, shell=True, stderr=subprocess.STDOUT, text=True)
         except subprocess.CalledProcessError as e:
             output = e.output
-            logger.error("Command execution failed: %s", e)
+            console.print(f"[bold red]Command execution failed: {e}[/bold red]")
         console.print(f"\n[bold yellow]===== Sortie de la commande =====[/bold yellow]\n{output}")
         log_interaction("Commande automatique exécutée", command_extracted, output)
     else:
         console.print(f"[yellow]Commande annulée.[/yellow]")
-        logger.info("Automatic command cancelled by user")
     console.print(f"[bold magenta]Coût API pour cette requête: ${cost:.5f}[/bold magenta]")
     console.print(f"[bold magenta]Coût total accumulé: ${total_api_cost:.5f}[/bold magenta]")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+rich

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault('OPENAI_API_KEY', 'test')
+import command
+
+class TestComputeCost(unittest.TestCase):
+    def test_compute_cost(self):
+        usage = SimpleNamespace(prompt_tokens=1000, completion_tokens=500)
+        cost = command.compute_cost('gpt-4o', usage)
+        expected = (1000/1_000_000)*2.50 + (500/1_000_000)*10.00
+        self.assertAlmostEqual(cost, expected, places=6)
+
+class TestGetGpt4Response(unittest.TestCase):
+    @patch('command.client')
+    def test_get_gpt4_response_success(self, mock_client):
+        fake_response = MagicMock()
+        fake_response.choices = [SimpleNamespace(message=SimpleNamespace(content='ok'))]
+        fake_response.usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1)
+        mock_client.chat.completions.create.return_value = fake_response
+
+        content, cost, usage = command.get_gpt4_response('hi', 'gpt-4o')
+        self.assertEqual(content, 'ok')
+        self.assertIsNotNone(usage)
+        self.assertGreater(cost, 0)
+
+    @patch('command.client')
+    def test_get_gpt4_response_error(self, mock_client):
+        mock_client.chat.completions.create.side_effect = Exception('fail')
+        content, cost, usage = command.get_gpt4_response('hi', 'gpt-4o')
+        self.assertEqual(content, '')
+        self.assertEqual(cost, 0.0)
+        self.assertIsNone(usage)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- configure OpenAI client from `OPENAI_API_KEY` environment variable
- rewrite README with setup instructions, usage and requirements

## Testing
- `python3 -m py_compile command.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4116c8c083218be664099346608b