### PR TITLE
Add IP based pentest mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Launch the assistant with:
 python command.py
 ```
 
+To automatically run basic reconnaissance against a target IP and let GPT suggest follow-up commands:
+
+```bash
+python command.py --ip 192.168.1.100
+```
+
 Choose one of the modes offered in the menu to start an interactive session or analyse command output. Errors are printed to the console and command transcripts are saved in `session.log` and `llm_analysis.txt`.
 
 To run the unit tests:

--- a/command.py
+++ b/command.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import os
 import re
+import argparse
 from openai import OpenAI
 from rich.console import Console
 from rich.markdown import Markdown
@@ -222,7 +223,68 @@ def execute_automatic_command(model):
     console.print(f"[bold magenta]Coût API pour cette requête: ${cost:.5f}[/bold magenta]")
     console.print(f"[bold magenta]Coût total accumulé: ${total_api_cost:.5f}[/bold magenta]")
 
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Pentest assistant")
+    parser.add_argument("--ip", help="target IP for automated recon")
+    return parser.parse_args()
+
+def _extract_first_command(text):
+    """Return the first shell command found in a markdown code block."""
+    match = re.search(r"```(?:bash)?\s*([\s\S]+?)\s*```", text)
+    if match:
+        cmd = match.group(1).strip().splitlines()[0]
+    else:
+        cmd = text.strip().splitlines()[0]
+    return cmd
+
+
+def run_ip_pentest(ip, model):
+    """Run an nmap scan then ask GPT which command to run next."""
+    console = Console()
+
+    # Step 1: run nmap
+    nmap_cmd = f"nmap -sC -sV {ip}"
+    console.print(f"[cyan]Running: {nmap_cmd}[/cyan]")
+    try:
+        nmap_output = subprocess.check_output(nmap_cmd, shell=True, stderr=subprocess.STDOUT, text=True)
+    except subprocess.CalledProcessError as e:
+        nmap_output = e.output
+    console.print(f"\n[bold yellow]===== Output of {nmap_cmd} =====[/bold yellow]\n{nmap_output}")
+
+    # Ask GPT what to run next based on the nmap output
+    ask_prompt = (
+        "Based on the following nmap results, suggest a single enumeration command "
+        "to run next. Return only the command formatted in a bash code block:\n\n"
+        + nmap_output
+    )
+    gpt_cmd, cost, _ = get_gpt4_response(ask_prompt, model)
+    update_total_cost(cost)
+    next_cmd = _extract_first_command(gpt_cmd)
+    console.print(f"\n[bold cyan]GPT suggests running:[/bold cyan] {next_cmd}")
+
+    # Execute the suggested command
+    console.print(f"[cyan]Running: {next_cmd}[/cyan]")
+    try:
+        cmd_output = subprocess.check_output(next_cmd, shell=True, stderr=subprocess.STDOUT, text=True)
+    except subprocess.CalledProcessError as e:
+        cmd_output = e.output
+    console.print(f"\n[bold yellow]===== Output of {next_cmd} =====[/bold yellow]\n{cmd_output}")
+
+    analyse_prompt = (
+        "Please analyse the following command output and suggest next steps for the pentest:\n\n"
+        + cmd_output
+    )
+    analysis, cost2, _ = get_gpt4_response(analyse_prompt, model)
+    update_total_cost(cost2)
+    console.print(f"[bold green]===== GPT Analysis =====[/bold green]")
+    md = Markdown(analysis)
+    console.print(md)
+    console.print(f"[bold magenta]Coût API pour cette requête: ${cost2:.5f}[/bold magenta]")
+    console.print(f"[bold magenta]Coût total accumulé: ${total_api_cost:.5f}[/bold magenta]")
+
 def main():
+    args = parse_args()
     console = Console()
     # Bannière audacieuse
     console.print("[bold magenta]============================================================[/bold magenta]")
@@ -239,6 +301,10 @@ def main():
     console.print(" - o1")
     user_model = input(f"{BOLD}{BLUE}Entrez le modèle à utiliser [par défaut 'gpt-4o']: {RESET}").strip()
     model = user_model if user_model else "gpt-4o"
+
+    if args.ip:
+        run_ip_pentest(args.ip, model)
+        return
     
     console.print("\n--------------------------------")
     console.print("[bold blue]Modes disponibles:[/bold blue]")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
+import sys
 
 os.environ.setdefault('OPENAI_API_KEY', 'test')
 import command
@@ -33,6 +34,22 @@ class TestGetGpt4Response(unittest.TestCase):
         self.assertEqual(content, '')
         self.assertEqual(cost, 0.0)
         self.assertIsNone(usage)
+
+class TestParseArgs(unittest.TestCase):
+    def test_parse_args_ip(self):
+        test_argv = ['cmd', '--ip', '10.0.0.1']
+        with patch.object(sys, 'argv', test_argv):
+            args = command.parse_args()
+        self.assertEqual(args.ip, '10.0.0.1')
+
+class TestMainIpMode(unittest.TestCase):
+    @patch('command.run_ip_pentest')
+    @patch('command.list_available_models')
+    def test_run_ip_pentest_called(self, mock_list, mock_run):
+        with patch('command.parse_args', return_value=SimpleNamespace(ip='1.1.1.1')):
+            with patch('builtins.input', return_value=''):
+                command.main()
+        mock_run.assert_called_once_with('1.1.1.1', 'gpt-4o')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support `--ip` argument with `argparse`
- implement `run_ip_pentest` to automate recon
- skip the interactive menu when `--ip` is provided
- document usage of `--ip`
- test new CLI parsing and call flow
- enhance automated mode to request GPT suggestions after the initial nmap scan

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f5ebbc720832186a979feb57e1a0f