### PR TITLE
Fix model handling for codex-mini and handle empty suggestions

### DIFF
--- a/command.py
+++ b/command.py
@@ -70,16 +70,25 @@ def get_gpt4_response(prompt, model):
     console = Console()
     try:
         with console.status("Chargement du modèle...", spinner="bouncingBar"):
-            response = client.chat.completions.create(
-                model=model,
-                messages=messages
-            )
+            if model.startswith("codex"):
+                response = client.responses.create(
+                    model=model,
+                    input=prompt,
+                    instructions=system_instructions,
+                )
+                content = response.output_text
+                usage = response.usage
+            else:
+                response = client.chat.completions.create(
+                    model=model,
+                    messages=messages
+                )
+                content = response.choices[0].message.content
+                usage = response.usage
     except Exception as e:
         console.print(f"[bold red]OpenAI API request failed: {e}[/bold red]")
         return "", 0.0, None
 
-    content = response.choices[0].message.content
-    usage = response.usage
     cost = compute_cost(model, usage)
     return content, cost, usage
 
@@ -235,7 +244,10 @@ def _extract_first_command(text):
     if match:
         cmd = match.group(1).strip().splitlines()[0]
     else:
-        cmd = text.strip().splitlines()[0]
+        stripped = text.strip()
+        if not stripped:
+            return ""
+        cmd = stripped.splitlines()[0]
     return cmd
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -35,6 +35,19 @@ class TestGetGpt4Response(unittest.TestCase):
         self.assertEqual(cost, 0.0)
         self.assertIsNone(usage)
 
+    @patch('command.client')
+    def test_get_gpt4_response_codex(self, mock_client):
+        fake_resp = MagicMock()
+        fake_resp.output_text = 'code'
+        fake_resp.usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1)
+        mock_client.responses.create.return_value = fake_resp
+
+        content, cost, usage = command.get_gpt4_response('print(1)', 'codex-mini-latest')
+        self.assertEqual(content, 'code')
+        self.assertIsNotNone(usage)
+        self.assertEqual(cost, 0.0)
+        mock_client.responses.create.assert_called_once()
+
 class TestParseArgs(unittest.TestCase):
     def test_parse_args_ip(self):
         test_argv = ['cmd', '--ip', '10.0.0.1']
@@ -50,6 +63,10 @@ class TestMainIpMode(unittest.TestCase):
             with patch('builtins.input', return_value=''):
                 command.main()
         mock_run.assert_called_once_with('1.1.1.1', 'gpt-4o')
+
+class TestExtractFirstCommand(unittest.TestCase):
+    def test_empty_string(self):
+        self.assertEqual(command._extract_first_command(''), '')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow codex models using OpenAI `responses.create`
- avoid crashes when GPT output is empty
- add unit tests for codex support and empty command extraction

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6841bdaf65ec832182c9c82df8cfeac4