### PR TITLE
Extend pentest workflow beyond enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Launch the assistant with:
 python command.py
 ```
 
-To automatically run basic reconnaissance against a target IP and let GPT suggest follow-up commands:
+To automatically run basic reconnaissance against a target IP and let GPT suggest follow-up enumeration and exploitation commands:
 
 ```bash
 python command.py --ip 192.168.1.100

--- a/command.py
+++ b/command.py
@@ -88,7 +88,6 @@ def get_gpt4_response(prompt, model):
     except Exception as e:
         console.print(f"[bold red]OpenAI API request failed: {e}[/bold red]")
         return "", 0.0, None
-
     cost = compute_cost(model, usage)
     return content, cost, usage
 
@@ -251,8 +250,8 @@ def _extract_first_command(text):
     return cmd
 
 
-def run_ip_pentest(ip, model):
-    """Run an nmap scan then ask GPT which command to run next."""
+def run_ip_pentest(ip, model, max_steps: int = 5):
+    """Run basic recon then let GPT guide enumeration and exploitation."""
     console = Console()
 
     # Step 1: run nmap
@@ -264,36 +263,84 @@ def run_ip_pentest(ip, model):
         nmap_output = e.output
     console.print(f"\n[bold yellow]===== Output of {nmap_cmd} =====[/bold yellow]\n{nmap_output}")
 
-    # Ask GPT what to run next based on the nmap output
-    ask_prompt = (
-        "Based on the following nmap results, suggest a single enumeration command "
-        "to run next. Return only the command formatted in a bash code block:\n\n"
-        + nmap_output
-    )
-    gpt_cmd, cost, _ = get_gpt4_response(ask_prompt, model)
-    update_total_cost(cost)
-    next_cmd = _extract_first_command(gpt_cmd)
-    console.print(f"\n[bold cyan]GPT suggests running:[/bold cyan] {next_cmd}")
+    previous_output = nmap_output
+    enumeration_history = [nmap_output]
 
-    # Execute the suggested command
-    console.print(f"[cyan]Running: {next_cmd}[/cyan]")
-    try:
-        cmd_output = subprocess.check_output(next_cmd, shell=True, stderr=subprocess.STDOUT, text=True)
-    except subprocess.CalledProcessError as e:
-        cmd_output = e.output
-    console.print(f"\n[bold yellow]===== Output of {next_cmd} =====[/bold yellow]\n{cmd_output}")
+    for _ in range(max_steps):
+        ask_prompt = (
+            "Based on the following enumeration results, suggest a single enumeration command "
+            "to run next. If enumeration is complete, respond with 'exit'. "
+            "Return only the command formatted in a bash code block:\n\n" + previous_output
+        )
+        gpt_cmd, cost, _ = get_gpt4_response(ask_prompt, model)
+        update_total_cost(cost)
+        next_cmd = _extract_first_command(gpt_cmd)
 
-    analyse_prompt = (
-        "Please analyse the following command output and suggest next steps for the pentest:\n\n"
-        + cmd_output
-    )
-    analysis, cost2, _ = get_gpt4_response(analyse_prompt, model)
-    update_total_cost(cost2)
-    console.print(f"[bold green]===== GPT Analysis =====[/bold green]")
-    md = Markdown(analysis)
-    console.print(md)
-    console.print(f"[bold magenta]Coût API pour cette requête: ${cost2:.5f}[/bold magenta]")
-    console.print(f"[bold magenta]Coût total accumulé: ${total_api_cost:.5f}[/bold magenta]")
+        if next_cmd.lower() in {"exit", "quit", ""}:
+            console.print("[green]GPT indicated the enumeration is complete.[/green]")
+            break
+
+        console.print(f"\n[bold cyan]GPT suggests running:[/bold cyan] {next_cmd}")
+        console.print(f"[cyan]Running: {next_cmd}[/cyan]")
+        try:
+            cmd_output = subprocess.check_output(next_cmd, shell=True, stderr=subprocess.STDOUT, text=True)
+        except subprocess.CalledProcessError as e:
+            cmd_output = e.output
+        console.print(f"\n[bold yellow]===== Output of {next_cmd} =====[/bold yellow]\n{cmd_output}")
+
+        analyse_prompt = (
+            "Please analyse the following command output and suggest next steps for the pentest. "
+            "If enumeration seems complete, say 'exit'.\n\n" + cmd_output
+        )
+        analysis, cost2, _ = get_gpt4_response(analyse_prompt, model)
+        update_total_cost(cost2)
+        console.print(f"[bold green]===== GPT Analysis =====[/bold green]")
+        md = Markdown(analysis)
+        console.print(md)
+        console.print(f"[bold magenta]Coût API pour cette requête: ${cost2:.5f}[/bold magenta]")
+        console.print(f"[bold magenta]Coût total accumulé: ${total_api_cost:.5f}[/bold magenta]")
+
+        previous_output = cmd_output
+        enumeration_history.append(cmd_output)
+
+    exploit_context = "\n".join(enumeration_history)
+    previous_output = exploit_context
+
+    for _ in range(max_steps):
+        ask_prompt = (
+            "Based on the following information, suggest a single exploitation command to run next. "
+            "If exploitation is complete or no more actions remain, respond with 'exit'. "
+            "Return only the command formatted in a bash code block:\n\n" + previous_output
+        )
+        gpt_cmd, cost, _ = get_gpt4_response(ask_prompt, model)
+        update_total_cost(cost)
+        next_cmd = _extract_first_command(gpt_cmd)
+
+        if next_cmd.lower() in {"exit", "quit", ""}:
+            console.print("[green]GPT indicated the exploitation phase is complete.[/green]")
+            break
+
+        console.print(f"\n[bold cyan]GPT suggests running:[/bold cyan] {next_cmd}")
+        console.print(f"[cyan]Running: {next_cmd}[/cyan]")
+        try:
+            cmd_output = subprocess.check_output(next_cmd, shell=True, stderr=subprocess.STDOUT, text=True)
+        except subprocess.CalledProcessError as e:
+            cmd_output = e.output
+        console.print(f"\n[bold yellow]===== Output of {next_cmd} =====[/bold yellow]\n{cmd_output}")
+
+        analyse_prompt = (
+            "Please analyse the following command output and suggest next exploitation steps. "
+            "Say 'exit' when done.\n\n" + cmd_output
+        )
+        analysis, cost2, _ = get_gpt4_response(analyse_prompt, model)
+        update_total_cost(cost2)
+        console.print(f"[bold green]===== GPT Analysis =====[/bold green]")
+        md = Markdown(analysis)
+        console.print(md)
+        console.print(f"[bold magenta]Coût API pour cette requête: ${cost2:.5f}[/bold magenta]")
+        console.print(f"[bold magenta]Coût total accumulé: ${total_api_cost:.5f}[/bold magenta]")
+
+        previous_output = cmd_output
 
 def main():
     args = parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+-e .
 openai
 rich

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup(name='pentest_agent', py_modules=['command'])


### PR DESCRIPTION
## Summary
- run enumeration until GPT says exit then move on to exploitation
- document expanded automation in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841bfdab7ac8321b296901c1a2be46a